### PR TITLE
move ShareBuild to the core api instead of build

### DIFF
--- a/proto/depot/build/v1/build.proto
+++ b/proto/depot/build/v1/build.proto
@@ -4,8 +4,6 @@ package depot.build.v1;
 service BuildService {
   rpc CreateBuild(CreateBuildRequest) returns (CreateBuildResponse);
   rpc FinishBuild(FinishBuildRequest) returns (FinishBuildResponse);
-  rpc ShareBuild(ShareBuildRequest) returns (ShareBuildResponse);
-  rpc StopSharingBuild(StopSharingBuildRequest) returns (StopSharingBuildResponse);
 }
 
 message CreateBuildRequest {
@@ -32,17 +30,3 @@ message FinishBuildRequest {
 }
 
 message FinishBuildResponse {}
-
-message ShareBuildRequest {
-  string build_id = 1;
-}
-
-message ShareBuildResponse {
-  string share_url = 1;
-}
-
-message StopSharingBuildRequest {
-  string build_id = 1;
-}
-
-message StopSharingBuildResponse {}

--- a/proto/depot/core/v1/build.proto
+++ b/proto/depot/core/v1/build.proto
@@ -1,0 +1,24 @@
+syntax = "proto3";
+package depot.core.v1;
+
+service BuildService {
+  // Share a URL to a build with users outside of your organization
+  rpc ShareBuild(ShareBuildRequest) returns (ShareBuildResponse);
+
+  // Stop sharing a build
+  rpc StopSharingBuild(StopSharingBuildRequest) returns (StopSharingBuildResponse);
+}
+
+message ShareBuildRequest {
+  string build_id = 1;
+}
+
+message ShareBuildResponse {
+  string share_url = 1;
+}
+
+message StopSharingBuildRequest {
+  string build_id = 1;
+}
+
+message StopSharingBuildResponse {}

--- a/proto/depot/core/v1/project.proto
+++ b/proto/depot/core/v1/project.proto
@@ -42,6 +42,12 @@ service ProjectService {
 
   // Delete project API token.
   rpc DeleteToken(DeleteTokenRequest) returns (DeleteTokenResponse) {}
+
+  // Share a URL to a build with users outside of your organization
+  rpc ShareBuild(ShareBuildRequest) returns (ShareBuildResponse);
+
+  // Stop sharing a build
+  rpc StopSharingBuild(StopSharingBuildRequest) returns (StopSharingBuildResponse);
 }
 
 message Project {
@@ -214,3 +220,17 @@ message DeleteTokenRequest {
 }
 
 message DeleteTokenResponse {}
+
+message ShareBuildRequest {
+  string build_id = 1;
+}
+
+message ShareBuildResponse {
+  string share_url = 1;
+}
+
+message StopSharingBuildRequest {
+  string build_id = 1;
+}
+
+message StopSharingBuildResponse {}

--- a/proto/depot/core/v1/project.proto
+++ b/proto/depot/core/v1/project.proto
@@ -42,12 +42,6 @@ service ProjectService {
 
   // Delete project API token.
   rpc DeleteToken(DeleteTokenRequest) returns (DeleteTokenResponse) {}
-
-  // Share a URL to a build with users outside of your organization
-  rpc ShareBuild(ShareBuildRequest) returns (ShareBuildResponse);
-
-  // Stop sharing a build
-  rpc StopSharingBuild(StopSharingBuildRequest) returns (StopSharingBuildResponse);
 }
 
 message Project {
@@ -220,17 +214,3 @@ message DeleteTokenRequest {
 }
 
 message DeleteTokenResponse {}
-
-message ShareBuildRequest {
-  string build_id = 1;
-}
-
-message ShareBuildResponse {
-  string share_url = 1;
-}
-
-message StopSharingBuildRequest {
-  string build_id = 1;
-}
-
-message StopSharingBuildResponse {}


### PR DESCRIPTION
the build API is specifically meant for build orchestration