### PR TITLE
feat: add logging APIs to build.proto

### DIFF
--- a/proto/depot/build/v1/build.proto
+++ b/proto/depot/build/v1/build.proto
@@ -1,9 +1,14 @@
 syntax = "proto3";
 package depot.build.v1;
 
+import "google/protobuf/timestamp.proto";
+
 service BuildService {
   rpc CreateBuild(CreateBuildRequest) returns (CreateBuildResponse);
   rpc FinishBuild(FinishBuildRequest) returns (FinishBuildResponse);
+
+  rpc GetBuildSteps(GetBuildStepsRequest) returns (GetBuildStepsResponse);
+  rpc GetBuildStepLogs(GetBuildStepLogsRequest) returns (GetBuildStepLogsResponse);
 }
 
 message CreateBuildRequest {
@@ -30,3 +35,45 @@ message FinishBuildRequest {
 }
 
 message FinishBuildResponse {}
+
+
+message GetBuildStepsRequest {
+  string project_id = 1;
+  string build_id = 2;
+}
+
+enum CacheState {
+  CACHE_STATE_UNSPECIFIED = 0;
+  CACHE_STATE_UNCACHED = 1;
+  CACHE_STATE_CACHED = 2;
+}
+
+message BuildStep {
+  string name = 1;
+  string digest = 2;
+  google.protobuf.Timestamp started_at = 3;
+  optional google.protobuf.Timestamp completed_at = 4;
+  CacheState cache_state = 5;
+  optional string error = 6;
+  bool has_logs = 7;
+
+}
+
+message GetBuildStepsResponse {
+  repeated BuildStep build_steps = 1;
+}
+
+message GetBuildStepLogsRequest {
+  string project_id = 1;
+  string build_id = 2;
+  string build_step_digest = 3;
+}
+
+message Log {
+  string message = 1;
+  google.protobuf.Timestamp timestamp = 2;
+}
+
+message GetBuildStepLogsResponse {
+  repeated Log logs = 1;
+}

--- a/proto/depot/build/v1/build.proto
+++ b/proto/depot/build/v1/build.proto
@@ -40,6 +40,9 @@ message FinishBuildResponse {}
 message GetBuildStepsRequest {
   string project_id = 1;
   string build_id = 2;
+
+  optional int32 page_size = 3;
+  optional string page_token = 4;
 }
 
 enum CacheState {
@@ -56,17 +59,21 @@ message BuildStep {
   CacheState cache_state = 5;
   optional string error = 6;
   bool has_logs = 7;
-
 }
 
 message GetBuildStepsResponse {
   repeated BuildStep build_steps = 1;
+  optional string next_page_token = 2;
 }
 
 message GetBuildStepLogsRequest {
   string project_id = 1;
   string build_id = 2;
   string build_step_digest = 3;
+
+
+  optional int32 page_size = 4;
+  optional string page_token = 5;
 }
 
 message Log {
@@ -76,4 +83,5 @@ message Log {
 
 message GetBuildStepLogsResponse {
   repeated Log logs = 1;
+  optional string next_page_token = 6;
 }

--- a/proto/depot/build/v1/build.proto
+++ b/proto/depot/build/v1/build.proto
@@ -36,7 +36,6 @@ message FinishBuildRequest {
 
 message FinishBuildResponse {}
 
-
 message GetBuildStepsRequest {
   string project_id = 1;
   string build_id = 2;
@@ -45,23 +44,23 @@ message GetBuildStepsRequest {
   optional string page_token = 4;
 }
 
-enum CacheState {
-  CACHE_STATE_UNSPECIFIED = 0;
-  CACHE_STATE_UNCACHED = 1;
-  CACHE_STATE_CACHED = 2;
-}
-
-message BuildStep {
-  string name = 1;
-  string digest = 2;
-  google.protobuf.Timestamp started_at = 3;
-  optional google.protobuf.Timestamp completed_at = 4;
-  CacheState cache_state = 5;
-  optional string error = 6;
-  bool has_logs = 7;
-}
-
 message GetBuildStepsResponse {
+  message BuildStep {
+    enum CacheState {
+      CACHE_STATE_UNSPECIFIED = 0;
+      CACHE_STATE_UNCACHED = 1;
+      CACHE_STATE_CACHED = 2;
+    }
+
+    string name = 1;
+    string digest = 2;
+    google.protobuf.Timestamp started_at = 3;
+    optional google.protobuf.Timestamp completed_at = 4;
+    CacheState cache_state = 5;
+    optional string error = 6;
+    bool has_logs = 7;
+  }
+
   repeated BuildStep build_steps = 1;
   optional string next_page_token = 2;
 }
@@ -76,12 +75,11 @@ message GetBuildStepLogsRequest {
   optional string page_token = 5;
 }
 
-message Log {
-  string message = 1;
-  google.protobuf.Timestamp timestamp = 2;
-}
-
 message GetBuildStepLogsResponse {
+  message Log {
+    string message = 1;
+    google.protobuf.Timestamp timestamp = 2;
+  }
   repeated Log logs = 1;
   optional string next_page_token = 6;
 }


### PR DESCRIPTION
the GetbuildSteps API returns each build step, any errors returned back,
as well as whether or not the build step has any logs associated with it.

then, each build step will have several logs, which you can query using
the GetBuildStepLogs API.