### PR TITLE
Add GitLab trust policy proto

### DIFF
--- a/proto/depot/core/v1/project.proto
+++ b/proto/depot/core/v1/project.proto
@@ -155,6 +155,7 @@ message AddTrustPolicyRequest {
     TrustPolicy.Buildkite buildkite = 2;
     TrustPolicy.CircleCI circleci = 3;
     TrustPolicy.GitHub github = 4;
+    TrustPolicy.GitLab gitlab = 5;
   }
 }
 
@@ -175,6 +176,7 @@ message TrustPolicy {
     Buildkite buildkite = 2;
     CircleCI circleci = 3;
     GitHub github = 4;
+    GitLab gitlab = 5;
   }
 
   message GitHub {
@@ -193,6 +195,13 @@ message TrustPolicy {
   message Buildkite {
     string organization_slug = 1;
     string pipeline_slug = 2;
+  }
+
+  message GitLab {
+    // Stable GitLab namespace identifier.
+    string namespace_id = 1;
+    // Stable GitLab project identifier.
+    string project_id = 2;
   }
 }
 


### PR DESCRIPTION
## Summary

Adds GitLab as a container build trust policy provider in `depot.core.v1.ProjectService`.

The new `TrustPolicy.GitLab` message carries GitLab's stable `namespace_id` and `project_id` values, and the provider is added to both the `AddTrustPolicyRequest.provider` and `TrustPolicy.provider` oneofs using field number 5.

## Validation

- `buf lint`
- `buf breaking --against '.git#branch=main'`
- `buf format -w proto/depot/core/v1/project.proto`
- `git diff --check`
